### PR TITLE
FIX for the GoogleShopping result fields request

### DIFF
--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -3,7 +3,7 @@
 ## v1.1.5 (2017-10-16)
 
 ### Behoben
-- Es wurde ein Fehler behoben, das die Eigenschaften vom Typ int und float nicht korrekt exportiert wurden.
+- Es wurde ein Fehler behoben, bei dem Merkmale vom Typ Ganze Zahl und Kommazahl nicht korrekt exportiert wurden.
 
 ## v1.1.4 (2017-10-04)
 

--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -1,6 +1,6 @@
 # Release Notes für Elastic Export Google Shopping
 
-## v1.1.5 (2017-10-16)
+## v1.1.5 (2017-10-18)
 
 ### Behoben
 - Es wurde ein Fehler behoben, bei dem Merkmale vom Typ Ganze Zahl und Kommazahl nicht korrekt exportiert wurden.

--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -1,5 +1,10 @@
 # Release Notes für Elastic Export Google Shopping
 
+## v1.1.5 (2017-10-13)
+
+### Behoben
+- Es wurde ein Fehler behoben, bei dem die Merkmale und der Text nicht exportiert wurden.
+
 ## v1.1.4 (2017-10-04)
 
 ### Behoben

--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -1,9 +1,9 @@
 # Release Notes für Elastic Export Google Shopping
 
-## v1.1.5 (2017-10-13)
+## v1.1.5 (2017-10-16)
 
 ### Behoben
-- Es wurde ein Fehler behoben, bei dem die Merkmale und der Text nicht exportiert wurden.
+- Es wurde ein Fehler behoben, das die Eigenschaften vom Typ int und float nicht korrekt exportiert wurden.
 
 ## v1.1.4 (2017-10-04)
 

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -1,5 +1,10 @@
 # Release Notes for Elastic Export Google Shopping
 
+## v1.1.5 (2017-10-13)
+
+### Fixed
+- An issue was fixed which caused the properties and text to not be exported.
+
 ## v1.1.4 (2017-10-04)
 
 ### Fixed
@@ -34,6 +39,7 @@
 
 ### Fixed
 - An issue was fixed which caused the properties not to be exported if the property name was not set in german.
+
 ### Changed
 - Values for the columns "gender", "age_group", "size_system", "size_type" and "energy_efficiency_class" will be no longer
  removed, if they are not conform to the values given by Google Shopping.

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -3,7 +3,7 @@
 ## v1.1.5 (2017-10-16)
 
 ### Fixed
-- An issue was fixed which caused the properties of type int and float to not be correctly exported.
+- An issue was fixed which caused the properties of the type int and float to not be exported correctly.
 
 ## v1.1.4 (2017-10-04)
 

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -1,6 +1,6 @@
 # Release Notes for Elastic Export Google Shopping
 
-## v1.1.5 (2017-10-16)
+## v1.1.5 (2017-10-18)
 
 ### Fixed
 - An issue was fixed which caused the properties of the type int and float to not be exported correctly.

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -1,9 +1,9 @@
 # Release Notes for Elastic Export Google Shopping
 
-## v1.1.5 (2017-10-13)
+## v1.1.5 (2017-10-16)
 
 ### Fixed
-- An issue was fixed which caused the properties and text to not be exported.
+- An issue was fixed which caused the properties of type int and float to not be correctly exported.
 
 ## v1.1.4 (2017-10-04)
 

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "name": "ElasticExportGoogleShopping",
   "namespace": "ElasticExportGoogleShopping",
   "type": "export",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "license": "GNU AFFERO GENERAL PUBLIC LICENSE Version 3, 19 November 2007",
   "pluginIcon": "icon_plugin_md.png",
   "price": 0.00,

--- a/resources/lang/de/logs.properties
+++ b/resources/lang/de/logs.properties
@@ -1,2 +1,3 @@
-fillRowError = "Zeile konnte nicht geschrieben werden."
-esError		= "Elastic Search Fehler."
+fillRowError        = "Zeile konnte nicht geschrieben werden."
+esError             = "Elastic Search Fehler."
+numberOfVariations  = "Number of variations received from Elastic Search."

--- a/resources/lang/de/logs.properties
+++ b/resources/lang/de/logs.properties
@@ -1,3 +1,3 @@
 fillRowError        = "Zeile konnte nicht geschrieben werden."
 esError             = "Elastic Search Fehler."
-numberOfVariations  = "Number of variations received from Elastic Search."
+numberOfVariations  = "Von Elastic Search erhaltene Variantenanzahl."

--- a/resources/lang/en/logs.properties
+++ b/resources/lang/en/logs.properties
@@ -1,2 +1,3 @@
-fillRowError = "Row could not be written."
-esError		= "Elastic Search error."
+fillRowError        = "Row could not be written."
+esError             = "Elastic Search error."
+numberOfVariations  = "Number of variations received from Elastic Search."

--- a/src/Generator/GoogleShopping.php
+++ b/src/Generator/GoogleShopping.php
@@ -183,6 +183,13 @@ class GoogleShopping extends CSVPluginGenerator
 					]);
 				}
 
+				if(isset($resultList['total']))
+				{
+                    $this->getLogger(__METHOD__)->debug('ElasticExportGoogleShopping::logs.numberOfVariations', [
+                        'Number of variations received' => $resultList['total'],
+                    ]);
+                }
+
                 foreach($resultList['documents'] as $variation)
                 {
                     if($lines == $filter['limit'])

--- a/src/ResultField/GoogleShopping.php
+++ b/src/ResultField/GoogleShopping.php
@@ -41,16 +41,10 @@ class GoogleShopping extends ResultFields
     {
         $settings = $this->arrayHelper->buildMapFromObjectList($formatSettings, 'key', 'value');
         $reference = $settings->get('referrerId') ? $settings->get('referrerId') : self::GOOGLE_SHOPPING;
-        $list = [];
 
-        if($settings->get('nameId'))
-        {
-            $list[] = 'texts.name'.$settings->get('nameId');
-        }
-        else
-        {
-            $list[] = 'texts.name1';
-        }
+        $list = ['texts.urlPath', 'texts.lang'];
+
+        $list[] = ($settings->get('nameId')) ? 'texts.name' . $settings->get('nameId') : 'texts.name1';
 
         if ($settings->get('descriptionType') == 'itemShortDescription' ||
             $settings->get('previewTextType') == 'itemShortDescription')
@@ -74,10 +68,8 @@ class GoogleShopping extends ResultFields
             $list[] = 'texts.technicalData';
         }
 
-        $list[] = 'texts.lang';
 
         //Mutator
-
 		/**
 		 * @var BarcodeMutator $barcodeMutator
 		 */
@@ -141,7 +133,6 @@ class GoogleShopping extends ResultFields
 				'item.manufacturer.name',
 				'item.manufacturer.externalName',
                 'item.conditionApi',
-                'texts.urlPath',
 
                 // Variation
                 'id',
@@ -198,14 +189,16 @@ class GoogleShopping extends ResultFields
                 'properties.selection.name',
 				'properties.selection.lang',
 				'properties.texts.value',
-				'properties.texts.lang'
+				'properties.texts.lang',
+                'properties.valueInt',
+                'properties.valueFloat',
             ],
             [
                 $languageMutator,
                 $skuMutator,
                 $defaultCategoryMutator,
 				$barcodeMutator,
-				$keyMutator
+				$keyMutator,
             ],
         ];
 
@@ -237,7 +230,6 @@ class GoogleShopping extends ResultFields
 			'item.conditionApi',
 
 			// Variation
-			'id',
 			'variation.availability.id',
 			'variation.model',
 			'variation.releasedAt',
@@ -260,6 +252,9 @@ class GoogleShopping extends ResultFields
 				// Attributes
 				'attributes',
 
+                // Properties
+                'properties',
+
 				// Barcodes
 				'barcodes',
 
@@ -271,8 +266,11 @@ class GoogleShopping extends ResultFields
 				'images.item',
 				'images.variation',
 
-				//sku
+				// Sku
 				'skus',
+
+                // Texts
+                'texts',
 			],
 
 			'nestedKeys' => [
@@ -280,18 +278,30 @@ class GoogleShopping extends ResultFields
 				'attributes' => [
 					'attributeValueSetId',
 					'attributeId',
-					'valueId'
+					'valueId',
 				],
+
+                // Proprieties
+                'properties' => [
+                    'property.id',
+                    'property.valueType',
+                    'selection.name',
+                    'selection.lang',
+                    'texts.value',
+                    'texts.lang',
+                    'valueInt',
+                    'valueFloat',
+                ],
 
 				// Barcodes
 				'barcodes' => [
 					'code',
-					'type'
+					'type',
 				],
 
 				// Default categories
 				'defaultCategories' => [
-					'id'
+					'id',
 				],
 
 				// Images
@@ -320,12 +330,12 @@ class GoogleShopping extends ResultFields
 					'position',
 				],
 
-				//sku
+				// Sku
 				'skus' => [
 					'sku',
 				],
 
-				// texts
+				// Texts
 				'texts' => [
 					'urlPath',
 					'name1',


### PR DESCRIPTION
Now the GoogleShopping result fields include the properties of type Int and Float. Fields for property check were also added in the KeyMutator for null checks.

@plentymarkets/team-multichannel-koboldmaki 